### PR TITLE
Fix unit tests

### DIFF
--- a/src/regression_test.php
+++ b/src/regression_test.php
@@ -29,7 +29,7 @@
  * @package Feed
  * @subpackage Tests
  */
-class ezcTestRegressionTest extends ezcTestCase
+abstract class ezcTestRegressionTest extends ezcTestCase
 {
     /**
      * How to sort the test files: 'mtime' sorts by modification time, any other


### PR DESCRIPTION
Also fixes the following error that occurs when running Feed unit tests :

There was 1 failure:

1) Warning
No tests found in class "ezcTestRegressionTest".
