### PR TITLE
fix ezcTestConstraintSimilarImage for recent phpunit

### DIFF
--- a/src/constraint/image.php
+++ b/src/constraint/image.php
@@ -154,36 +154,22 @@ class ezcTestConstraintSimilarImage extends PHPUnit_Framework_Constraint
      * @param   boolean $not Flag to indicate negation.
      * @throws  PHPUnit_Framework_ExpectationFailedException
      */
-    public function fail( $other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL )
+    public function fail( $other, $description, SebastianBergmann\Comparator\ComparisonFailure  $comparisonFailure = NULL )
     {
         $failureDescription = sprintf(
           'Failed asserting that image "%s" is similar to image "%s".',
-
            $other,
            $this->filename
         );
-
-        if ($not) {
-            $failureDescription = self::negate($failureDescription);
-        }
 
         if (!empty($description)) {
             $failureDescription = $description . "\n" . $failureDescription;
         }
 
-        if (!$not) {
-            throw new PHPUnit_Framework_ExpectationFailedException(
-              $failureDescription,
-              PHPUnit_Framework_ComparisonFailure::diffEqual(
-                $this->delta,
-                $this->difference
-              )
-            );
-        } else {
-            throw new PHPUnit_Framework_ExpectationFailedException(
-              $failureDescription
-            );
-        }
+        throw new PHPUnit_Framework_ExpectationFailedException(
+          $failureDescription,
+          $comparisonFailure
+        );
     }
 
     /**


### PR DESCRIPTION
Discovered trying to run "Graph" test sutie with phpunit 4.6.10

- Fix function prototype.
- $not is not defined, so drop it
- diffEqual doesn't seems to exist, so clean it
- pass $comparisonFailure to PHPUnit_Framework_ExpectationFailedException

Perhaps @sebastianbergmann can check this change ?