### PR TITLE
fix thow and add assertAttributeEquals

### DIFF
--- a/src/test/case.php
+++ b/src/test/case.php
@@ -193,7 +193,8 @@ abstract class ezcTestCase extends PHPUnit\Framework\TestCase
         $reflectionObject = new ReflectionClass( $object );
         $reflectionProperty = $reflectionObject->getProperty( $attribute );
 
-        if (version_compare(PHP_VERSION, '8.1', '<')) {
+        if (version_compare( PHP_VERSION, '8.1', '<' ) )
+        {
             $reflectionProperty->setAccessible( true );
         }
 
@@ -209,7 +210,7 @@ abstract class ezcTestCase extends PHPUnit\Framework\TestCase
 
         return self::assertSame( $actualValue, $expectedValue );
     }
-    
+
     /**
      * Implementation of assertAttributeEquals that PHPUnit dropped
      */
@@ -218,6 +219,6 @@ abstract class ezcTestCase extends PHPUnit\Framework\TestCase
         $actualValue = self::readAttribute( $object, $property );
 
         return self::assertEquals( $actualValue, $expectedValue );
-    }  
+    }
 }
 ?>

--- a/src/test/case.php
+++ b/src/test/case.php
@@ -182,7 +182,7 @@ abstract class ezcTestCase extends PHPUnit\Framework\TestCase
             return $this->getMockBuilder( $arguments[0] )->setMethods( $arguments[1] ?? [] )->getMock();
         }
 
-        throw BadMethodCallException( $method . ' does not exist.' );
+        throw new BadMethodCallException( $method . ' does not exist.' );
     }
 
     /**
@@ -209,5 +209,15 @@ abstract class ezcTestCase extends PHPUnit\Framework\TestCase
 
         return self::assertSame( $actualValue, $expectedValue );
     }
+    
+    /**
+     * Implementation of assertAttributeEquals that PHPUnit dropped
+     */
+    public static function assertAttributeEquals( $expectedValue, $property, $object )
+    {
+        $actualValue = self::readAttribute( $object, $property );
+
+        return self::assertEquals( $actualValue, $expectedValue );
+    }  
 }
 ?>


### PR DESCRIPTION
Running ConsoleTools test suite
```
There were 9 errors:

1) ezcConsoleArgumentsTest::testOffsetUnsetSuccess
Error: Call to undefined function BadMethodCallException()
...
```

Fixing the `throw`

```
There were 9 errors:

1) ezcConsoleArgumentsTest::testOffsetUnsetSuccess
BadMethodCallException: assertAttributeEquals does not exist.
...
```



Using this

```
PHPUnit 9.5.21 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 744 (  8%)
............................................................... 126 / 744 ( 16%)
............................................................... 189 / 744 ( 25%)
............................................................... 252 / 744 ( 33%)
............................................................... 315 / 744 ( 42%)
............................................................... 378 / 744 ( 50%)
............................................................... 441 / 744 ( 59%)
............................................................... 504 / 744 ( 67%)
............................................................... 567 / 744 ( 76%)
............................................................... 630 / 744 ( 84%)
............................................................... 693 / 744 ( 93%)
...................................................             744 / 744 (100%)

Time: 00:00.115, Memory: 10.00 MB

OK (744 tests, 1557 assertions)
```


P.S. CS failure doesn't seems related to these changes